### PR TITLE
update naarad version to fix naarad related errors.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,8 @@
 
 # -*- coding: utf-8 -*-
 import sys, os, datetime
-
+sys.path.append("/Users/avenkatr/Zopkio")
+import zopkio
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,8 +20,6 @@
 
 # -*- coding: utf-8 -*-
 import sys, os, datetime
-sys.path.append("/Users/avenkatr/Zopkio")
-import zopkio
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx']

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,7 @@
+zopkio
+======
+
+.. toctree::
+   :maxdepth: 4
+
+   zopkio

--- a/docs/zopkio.rst
+++ b/docs/zopkio.rst
@@ -1,0 +1,134 @@
+zopkio package
+==============
+
+Submodules
+----------
+
+zopkio.adhoc_deployer module
+----------------------------
+
+.. automodule:: zopkio.adhoc_deployer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.configobj module
+-----------------------
+
+.. automodule:: zopkio.configobj
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.constants module
+-----------------------
+
+.. automodule:: zopkio.constants
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.deployer module
+----------------------
+
+.. automodule:: zopkio.deployer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.error_messages module
+----------------------------
+
+.. automodule:: zopkio.error_messages
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.recipes module
+---------------------
+
+.. automodule:: zopkio.recipes
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.remote_host_helper module
+--------------------------------
+
+.. automodule:: zopkio.remote_host_helper
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.reporter module
+----------------------
+
+.. automodule:: zopkio.reporter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.results_collector module
+-------------------------------
+
+.. automodule:: zopkio.results_collector
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.runtime module
+---------------------
+
+.. automodule:: zopkio.runtime
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.test_runner module
+-------------------------
+
+.. automodule:: zopkio.test_runner
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.test_runner_helper module
+--------------------------------
+
+.. automodule:: zopkio.test_runner_helper
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.test_utils module
+------------------------
+
+.. automodule:: zopkio.test_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.testobj module
+---------------------
+
+.. automodule:: zopkio.testobj
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+zopkio.utils module
+-------------------
+
+.. automodule:: zopkio.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: zopkio
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy>=1.7.0
+argparse
+pytz>=2013.8
+jinja2
+luminol
+python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -60,10 +60,11 @@ setup(
   install_requires=[
       'argparse>=1.2.1',
       'numpy>=1.7.0',
-      'naarad==1.0.8',
+      'naarad>=1.0.8',
       'paramiko>=1.15.1',
       'pytz>=2014.7',
       'jinja2>=2.7.3',
+      'python-dateutil',
       'kazoo>=2.0'
   ],
   entry_points = {


### PR DESCRIPTION
 These errors show up in zopkio even when matplotlib is installed.
[ERROR] Naarad cannot import graphing library matplotlib on your system.

The rest of the changes are for publishing the docs on readtheorgs