### PR TITLE
cleanup by killing all deployer initiated process in the final block.…

### DIFF
--- a/zopkio/adhoc_deployer.py
+++ b/zopkio/adhoc_deployer.py
@@ -419,3 +419,13 @@ class SSHDeployer(Deployer):
     :Returns: A list of Processes
     """
     return self.processes.values()
+
+  def kill_all_process(self):
+    """ Terminates all the running processes. By default it is set to false.
+    Users can set to true in config once the method to get_pid is done deterministically
+    either using pid_file or an accurate keyword
+
+    """
+    if (runtime.get_active_config("cleanup_pending_process",False)):
+      for process in self.get_processes():
+        self.terminate(process.unique_id)

--- a/zopkio/deployer.py
+++ b/zopkio/deployer.py
@@ -123,6 +123,12 @@ class Deployer(object):
     """
     raise NotImplementedError
 
+  def kill_all_process(self):
+    """ Terminates all the running processes
+
+    """
+    raise NotImplementedError
+
   def soft_bounce(self, unique_id, configs=None):
     """ Performs a soft bouce (stop and start) for the specified process
 
@@ -187,13 +193,6 @@ class Deployer(object):
       hostname = self.processes[unique_id].hostname
       with get_ssh_client(hostname, username=runtime.get_username(), password=runtime.get_password()) as ssh:
         better_exec_command(ssh, "kill -9 {0}".format(pid_str), "KILLING PROCESS {0}".format(unique_id))
-
-  def kill_all_process(self):
-    """ Terminates all the running processes
-
-    """
-    for process in self.get_processes():
-      self.terminate(process.unique_id)
 
   def terminate(self, unique_id, configs=None):
     """ Issues a kill -15 to the specified process

--- a/zopkio/test_runner.py
+++ b/zopkio/test_runner.py
@@ -157,13 +157,10 @@ class TestRunner(object):
               if not setup_fail:
                 failure_handler.notify_failure()
               logger.error("{0} failed teardown_suite(). {1}".format(config.name, traceback.format_exc()))
-
-            # kill all orphaned process
-            # TODO : Make this true by default once we fix the correct way to get pid
-            # Currently the way we extract pid without any pid_keyword or pid_file can cause bad kills
-            if (runtime.get_active_config("cleanup_pending_process",False)):
-              for deployer in runtime.get_deployers():
-                deployer.kill_all_process()
+        finally:
+          # kill all orphaned process
+          for deployer in runtime.get_deployers():
+            deployer.kill_all_process()
 
         config.end_time = time.time()
         logger.info("Execution of configuration: {0} complete".format(config.name))


### PR DESCRIPTION
… For ssh deployer it is configurable with default config set to false.

If users have correct ways to implement get_pid using keyword or file then it can be set to true in test configs.