### PR TITLE
Update to be more pythonic and use abc module for declaring abstract …

### DIFF
--- a/test/test_deployer.py
+++ b/test/test_deployer.py
@@ -24,6 +24,37 @@ from zopkio.deployer import Deployer, Process
 from zopkio.remote_host_helper import ParamikoError, better_exec_command, get_ssh_client, copy_dir, get_sftp_client
 
 class TestDeployer(unittest.TestCase):
+
+  class DeployerStub( Deployer):
+    """
+    Test stub class to make a concrete class out of abstract Deployer class that does nothing
+    """
+
+    def install(self, unique_id, configs=None):
+      pass
+
+    def start(self, unique_id, configs=None):
+      pass
+
+    def stop(self, unique_id, configs=None):
+      pass
+
+
+    def uninstall(self, unique_id, configs=None):
+      pass
+
+    def get_pid(self, unique_id, configs=None):
+      pass
+
+    def get_host(self, unique_id):
+      pass
+
+    def get_processes(self):
+      pass
+
+    def kill_all_process(self):
+      pass
+
   def test_better_exec(self):
     """
     Tests that the better_exec in the deployer module works and detects failed
@@ -39,7 +70,7 @@ class TestDeployer(unittest.TestCase):
     Tests that we can successfully copy logs from a remote host
     :return:
     """
-    minimial_deployer = Deployer()
+    minimial_deployer = TestDeployer.DeployerStub()
     install_path = '/tmp/test_deployer_get_logs'
     if not os.path.exists(install_path):
       os.mkdir(install_path)


### PR DESCRIPTION
Update to be more pythonic and use abc module for declaring abstract classes/methods
Cleaned up cookie-cutter replicated code for sending signals to remote processes

===============================
Please Note:  This does not address a bug so much as some clean up after learning/reviewing the code base.  One part of these updates will now require the contract found in abstract methods in Deployer class be implemented to work, rather than having exceptions raised if not.  This could represent a non-backwards compatible change which should be discussed